### PR TITLE
Experiment with simplified `.coveragerc`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,28 +1,10 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
-source = cookiecutter
+source = pyscaffoldext.cookiecutter
 # omit = bad_file.py
 
 [paths]
 source =
     src/
     */site-packages/
-
-[report]
-# Regexes for lines to exclude from consideration
-exclude_lines =
-    # Have to re-enable the standard pragma
-    pragma: no cover
-
-    # Don't complain about missing debug-only code:
-    def __repr__
-    if self\.debug
-
-    # Don't complain if tests don't hit defensive assertion code:
-    raise AssertionError
-    raise NotImplementedError
-
-    # Don't complain if non-runnable code isn't run:
-    if 0:
-    if __name__ == .__main__.:

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ pyscaffold.cli =
 # CAUTION: --cov flags may prohibit setting breakpoints while debugging.
 #          Comment those flags to avoid this py.test issue.
 addopts =
-    --cov pyscaffoldext.cookiecutter --cov-report term-missing
+    --cov --cov-report term-missing
     --verbose
 norecursedirs =
     dist


### PR DESCRIPTION
This is an experiment to check if a simplification of PyScaffold's `.coveragerc` template is viable.